### PR TITLE
Async builds: add celery and redis images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,21 @@ services:
     environment:
       - DEBUG
       - SECRET_KEY
+
+  redis:
+     image: redis:latest
+
+  celery:
+    build:
+        context: ./rapstore-django/celery
+        dockerfile: Dockerfile
+    command: celery worker --app=api.tasks
+    environment:
+      - DEBUG
+      - SECRET_KEY
+    volumes:
+      - ./rapstore-django/django:/code
+      - riot:/RIOT
+
 volumes:
     postgres-data:


### PR DESCRIPTION
This PR adds celery and redis as images in Docker Container files. Required for asynchronous builds