### PR TITLE
Correct behaviour for sub-endpoints

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -49,7 +49,7 @@ server {
     location / {
       proxy_pass    http://127.0.0.1:4200;
     }
-    location /ota {
+    location /ota/ {
       proxy_pass    http://127.0.0.1:4000/;
     }
 }


### PR DESCRIPTION
e.g. dev.riot-apps.net/ota/files was resolving to localhost:4000//files, and returning 404. This corrects that.